### PR TITLE
Use tokio_timer for connection timeout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 extern crate env_logger;
 #[macro_use] extern crate futures;
 #[macro_use] extern crate tokio_core;
+extern crate tokio_timer;
 
 // pub mod for now until the entire API is used internally
 pub mod pool;
@@ -51,7 +52,7 @@ fn main() {
 
         // create a timeout future and map it to Err
         // this gives us future that will map to std::result::Result<_, Timeout>
-        let connect_timer = futures::finished(timeout).map(Err);
+        let connect_timer = timeout.map(Err);
 
         // TODO turn this into a pool managed by raft
         let backend = pool.get().unwrap();


### PR DESCRIPTION
As reported by @yanns, the timer implementation I had wrote was finishing
instantly and would not wait for the Timeout duration.

Fixes #1