### PR TITLE
Create Pool management API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,11 +8,13 @@ dependencies = [
  "hyper 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustful 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-proto 0.1.0 (git+https://github.com/tokio-rs/tokio-proto)",
  "tokio-service 0.1.0 (git+https://github.com/tokio-rs/tokio-service)",
  "tokio-timer 0.1.0 (git+https://github.com/tokio-rs/tokio-timer)",
+ "uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -624,6 +626,14 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "uuid"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +732,7 @@ dependencies = [
 "checksum url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "48ccf7bd87a81b769cf84ad556e034541fb90e1cd6d4bc375c822ed9500cd9d7"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
+"checksum uuid 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a9ff57156caf7e22f37baf3c9d8f6ce8194842c23419dafcb0716024514d162"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ bytes = { git = "https://github.com/carllerche/bytes" }
 nom = "1.2.4"
 
 rustful = "0.9"
+rustc-serialize = "0.3.19"
+uuid = { version = "0.3.1", features = ["v4"] }
 
 [dev-dependencies]
 hyper = "0.9"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # Alacrity
 
-A HTTP 1.1 proxy written in Rust using tokio.
+A HTTP 1.1 load balancer written in Rust using tokio.
 
 ## Design
 
-The goal is to build a proxy that works well in the dynamic VM/container environments that are starting to be more common.
+The goal is to build an ELB-like load balancer that works well in the dynamic VM/container environments that are starting to be more common. It is expected that one load balancer be used for one cluster. As such, there is no
 
-   * Servers must register with the proxy using an HTTP POST to the management IP.
+
+   * Servers must register with the load balancer using an HTTP POST to the management IP.
       * The POST payload contains the health check information.
-   * The proxy will keep that server active in the pool as long as the health succeeds.
-   * The pool is managed by Raft, allowing a cluster of redundant proxy servers. This should allow an active/passive setup out of the box.
+   * The load balancer will keep that server active in the pool as long as the health succeeds.
+   * The pool is managed by Raft, allowing a cluster of redundant load balancer servers. This should allow an active/passive setup out of the box.
       * Note: The [raft-rs](https://github.com/Hoverbear/raft-rs) crate does not currently support dynamic membership.
    * Async IO is done using tokio-core (which is built on top of mio).
 

--- a/src/alacrity.rs
+++ b/src/alacrity.rs
@@ -3,8 +3,10 @@ extern crate alacrity;
 
 use std::env;
 use std::net::SocketAddr;
+use std::thread;
 
 use alacrity::pool::Pool;
+use alacrity::mgmt;
 
 fn main() {
     env_logger::init().unwrap();
@@ -13,7 +15,15 @@ fn main() {
     let addr = addr.parse::<SocketAddr>().unwrap();
 
     let backend = env::args().nth(2).unwrap_or("127.0.0.1:12345".to_string());
-    let pool = Pool::new(vec![backend]).unwrap();
+    let backend = backend.parse::<SocketAddr>().unwrap();
+    let pool = Pool::with_servers(vec![backend]);
 
-    alacrity::proxy::listen(addr, pool.clone()).expect("Failed to start server")
+    let admin_ip = env::args().nth(2).unwrap_or("127.0.0.1:8687".to_string());
+    let admin_addr = admin_ip.parse::<SocketAddr>().unwrap();
+    let p = pool.clone();
+    let _ = thread::Builder::new().name("management".to_string()).spawn(move || {
+        mgmt::listen(admin_addr, p);
+    }).expect("Failed to create proxy thread");
+
+    alacrity::proxy::listen(addr, pool.clone()).expect("Failed to start server");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ extern crate bytes;
 #[macro_use] extern crate nom;
 #[macro_use] extern crate log;
 extern crate env_logger;
+#[macro_use] extern crate rustful;
+extern crate rustc_serialize;
+extern crate uuid;
 
 // pub mod for now until the entire API is used internally
 pub mod pool;
@@ -15,3 +18,4 @@ mod framed;
 pub mod proxy;
 mod backend;
 mod frontend;
+pub mod mgmt;

--- a/src/mgmt.rs
+++ b/src/mgmt.rs
@@ -1,0 +1,83 @@
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
+
+use rustful::{Server, Context, Response, TreeRouter};
+use rustc_serialize::json;
+
+use pool::Pool;
+
+#[derive(Debug, RustcDecodable, RustcEncodable)]
+struct PoolServers {
+    pub servers: Vec<PoolServer>,
+}
+
+#[derive(Debug, RustcDecodable, RustcEncodable)]
+struct PoolServer {
+    pub ip: String,
+    pub port: String,
+}
+
+fn index(_context: Context, response: Response) {
+    response.send("Alacrity Management API");
+}
+
+fn get_servers(context: Context, response: Response) {
+    let pool: &Pool = context.global.get().expect("Failed to get global pool");
+    let addr = pool.get().expect("Failed to get address from pool");
+    let ip = match addr.ip() {
+        IpAddr::V4(v4) => format!("{}", v4),
+        _ => unimplemented!(),
+    };
+    let servers = vec![
+        PoolServer {
+            ip: ip,
+            port: format!("{}", addr.port()),
+        }
+    ];
+
+    response.send(json::encode(&servers).expect("Failed to encode into json"))
+}
+
+fn add_server(mut context: Context, response: Response) {
+
+    let server: PoolServer = context.body.decode_json_body().expect("Failed to decode body");
+    debug!("body = {:?}", server);
+
+    let pool: &Pool = context.global.get().expect("Failed to get global pool");
+    let ip = format!("{}:{}", server.ip, server.port);
+    pool.add(FromStr::from_str(&ip).expect("Failed to parse socket addr"));
+    debug!("Added new IP to pool");
+
+    // TODO send the entire pool in response
+    response.send("Added new IP to pool");
+}
+
+fn remove_server(context: Context, response: Response) {
+
+    let pool: &Pool = context.global.get().expect("Failed to get global pool");
+    let host = context.variables.get("host").expect("Failed to get host");
+    let port = context.variables.get("port").expect("Failed to get port");
+    let addr = FromStr::from_str(format!("{}:{}", host, port).as_str()).expect("Failed to parse host and port");
+    pool.remove(&addr);
+    info!("Removed server {} from pool", &addr);
+
+    // TODO send the entire pool in response
+    response.send("Server removed");
+}
+
+pub fn listen(addr: SocketAddr, pool: Pool) {
+    Server {
+        host: addr.into(),
+        handlers: insert_routes!{
+            TreeRouter::new() => {
+                "/" => Get: index as fn(Context, Response),
+                "/servers" => Post: add_server as fn(Context, Response),
+                "/servers" => Get: get_servers as fn(Context, Response),
+                "/servers/:server_id" => Delete: remove_server as fn(Context, Response),
+            }
+        },
+        global: Box::new(pool).into(),
+        threads: Some(1),
+        ..Server::default()
+    }.run().expect("Could not start server");
+}

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,6 +1,5 @@
-use std::cell::RefCell;
-use std::net::{SocketAddr, AddrParseError};
-use std::rc::Rc;
+use std::net::SocketAddr;
+use std::sync::{Arc, RwLock};
 
 /// A round-robin pool for servers
 ///
@@ -9,33 +8,44 @@ use std::rc::Rc;
 /// Inspired by https://github.com/NicolasLM/nucleon/blob/master/src/backend.rs
 #[derive(Clone)]
 pub struct Pool {
-    inner: Rc<RefCell<inner::Pool>>,
+    inner: Arc<RwLock<inner::Pool>>,
 }
 
 impl Pool {
-    pub fn new(backends_str: Vec<String>) -> Result<Pool, AddrParseError> {
-        let inner = try!(inner::Pool::new(backends_str));
+    pub fn with_servers(backends: Vec<SocketAddr>) -> Pool {
+        let inner = inner::Pool::new(backends);
 
-        Ok(
-            Pool {
-                inner: Rc::new(RefCell::new(inner)),
-            }
-          )
+        Pool {
+            inner: Arc::new(RwLock::new(inner)),
+        }
     }
-
 
     /// Get a `SocketAddr` from the pool
     ///
     /// The pool may be exhausted of eligible addresses to connect to. The client is expected to
     /// handle this scenario.
     pub fn get(&self) -> Option<SocketAddr> {
-        self.inner.borrow_mut().get()
+        self.inner.write().expect("Lock is poisoned").get()
+    }
+
+    /// Add a new socket (IP address and port) to the pool
+    ///
+    /// Currently, it is possible to add the same socket more then once
+    pub fn add(&self, backend: SocketAddr) {
+        self.inner.write().expect("Lock is poisoned").add(backend)
+    }
+
+    /// Remove a socket from the pool
+    ///
+    /// This will remove all instance of the given socket. See `add` method for details on
+    /// duplicate sockets.
+    pub fn remove(&self, backend: &SocketAddr) {
+        self.inner.write().expect("Lock is poisoned").remove(backend)
     }
 }
 
 pub mod inner {
-    use std::net::{SocketAddr, AddrParseError};
-    use std::str::FromStr;
+    use std::net::SocketAddr;
 
     pub struct Pool {
         backends: Vec<SocketAddr>,
@@ -43,23 +53,12 @@ pub mod inner {
     }
 
     impl Pool {
-        pub fn new(backends_str: Vec<String>) -> Result<Pool, AddrParseError> {
-            let mut backends = Vec::new();
-
-            for backend_str in backends_str {
-                let backend_socket_addr: SocketAddr = try!(FromStr::from_str(&backend_str));
-                backends.push(backend_socket_addr);
-                info!("Load balancing server {:?}", backend_socket_addr);
-            }
-
-            Ok(Pool {
+        pub fn new(backends: Vec<SocketAddr>) -> Pool {
+            Pool {
                 backends: backends,
                 last_used: 0,
-            })
+            }
         }
-    }
-
-    impl Pool {
 
         pub fn get(&mut self) -> Option<SocketAddr> {
             if self.backends.is_empty() {
@@ -67,41 +66,36 @@ pub mod inner {
                 return None;
             }
             self.last_used = (self.last_used + 1) % self.backends.len();
-            self.backends.get(self.last_used).map(|b| {
-                debug!("Pool is cloaning (hehe) out {}", b);
-                b.clone()
+            self.backends.get(self.last_used).map(|&addr| {
+                debug!("Pool is cloaning (hehe) out {}", addr);
+                addr.clone()
             })
         }
 
-        /// Add a new socket (IP address and port) to the pool
-        ///
-        /// Currently, it is possible to add the same socket more then once
-        pub fn add(&mut self, backend_str: &str) -> Result<(), AddrParseError> {
-            let backend_socket_addr: SocketAddr = try!(FromStr::from_str(&backend_str));
-            self.backends.push(backend_socket_addr);
-            Ok(())
+        pub fn add(&mut self, backend: SocketAddr) {
+            self.backends.push(backend);
         }
 
-        /// Remove a socket from the pool
-        ///
-        /// This will remove all instance of the given socket. See `add` method for details on
-        /// duplicate sockets.
-        pub fn remove(&mut self, backend_str: &str) -> Result<(), AddrParseError> {
-            let backend_socket_addr: SocketAddr = try!(FromStr::from_str(&backend_str));
-            self.backends.retain(|&x| x != backend_socket_addr);
-            Ok(())
+        pub fn remove(&mut self, backend: &SocketAddr) {
+            self.backends.retain(|&addr| &addr != backend);
         }
     }
 
 
-#[cfg(test)]
+    #[cfg(test)]
     mod tests {
         use super::Pool;
+        use std::net::SocketAddr;
+        use std::str::FromStr;
 
         #[test]
         fn test_rrb_backend() {
-            let backends_str = vec!["127.0.0.1:6000".to_string(), "127.0.0.1:6001".to_string()];
-            let mut rrb = Pool::new(backends_str).unwrap();
+            let backends: Vec<SocketAddr> = vec![
+                FromStr::from_str("127.0.0.1:6000").unwrap(),
+                FromStr::from_str("127.0.0.1:6001").unwrap(),
+            ];
+
+            let mut rrb = Pool::new(backends);
             assert_eq!(2, rrb.backends.len());
 
             let first_socket_addr = rrb.get().unwrap();
@@ -115,33 +109,38 @@ pub mod inner {
 
         #[test]
         fn test_empty_rrb_backend() {
-            let backends_str = vec![];
-            let mut rrb = Pool::new(backends_str).unwrap();
+            let backends= vec![];
+            let mut rrb = Pool::new(backends);
             assert_eq!(0, rrb.backends.len());
             assert!(rrb.get().is_none());
         }
 
         #[test]
         fn test_add_to_rrb_backend() {
-            let mut rrb = Pool::new(vec![]).unwrap();
+            let mut rrb = Pool::new(vec![]);
             assert!(rrb.get().is_none());
-            assert!(rrb.add("327.0.0.1:6000").is_err());
-            assert!(rrb.get().is_none());
-            assert!(rrb.add("127.0.0.1:6000").is_ok());
+            rrb.add(FromStr::from_str("127.0.0.1:6000").unwrap());
             assert!(rrb.get().is_some());
         }
 
         #[test]
         fn test_remove_from_rrb_backend() {
-            let backends_str = vec!["127.0.0.1:6000".to_string(), "127.0.0.1:6001".to_string()];
-            let mut rrb = Pool::new(backends_str).unwrap();
-            assert!(rrb.remove("327.0.0.1:6000").is_err());
+            let mut rrb = Pool::new(vec![]);
+            rrb.add(FromStr::from_str("127.0.0.1:6000").unwrap());
+            rrb.add(FromStr::from_str("127.0.0.1:6001").unwrap());
             assert_eq!(2, rrb.backends.len());
-            assert!(rrb.remove("127.0.0.1:6000").is_ok());
-            assert_eq!(1, rrb.backends.len());
-            assert!(rrb.remove("127.0.0.1:6000").is_ok());
-            assert_eq!(1, rrb.backends.len());
-        }
 
+            let unknown_addr = FromStr::from_str("127.0.0.1:1234").unwrap();
+            rrb.remove(&unknown_addr);
+            assert_eq!(2, rrb.backends.len());
+
+            let addr1 = FromStr::from_str("127.0.0.1:6000").unwrap();
+            rrb.remove(&addr1);
+            assert_eq!(1, rrb.backends.len());
+
+            let addr2 = FromStr::from_str("127.0.0.1:6001").unwrap();
+            rrb.remove(&addr2);
+            assert_eq!(0, rrb.backends.len());
+        }
     }
 }


### PR DESCRIPTION
- A rustful server allows people to add, read and remove backends from a
  pool.
- The Pool was refactored so it could be used between multiple threads.
  I also changed the Pool interface so that it accepted sockets intead
  of a ip and port string.
- There main proxy now runs off the main thread.