### PR TITLE
Support a request content length body

### DIFF
--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -1,3 +1,4 @@
+use std::ascii::AsciiExt;
 use std::{io, slice, str, fmt};
 
 use tokio_core::io::EasyBuf;
@@ -34,7 +35,20 @@ impl Request {
         self.version
     }
 
-    pub fn headers(&self) -> RequestHeaders {
+    pub fn append_data(&mut self, buf: &[u8]) {
+        self.data.get_mut().extend_from_slice(buf);
+    }
+
+    pub fn content_length(&self) -> Option<usize> {
+        self.headers()
+            .find(|h| h.0.to_ascii_lowercase().as_str() == "content-length")
+            .and_then(|h| {
+                let v = ::std::str::from_utf8(&h.1).unwrap();
+                v.parse::<usize>().ok()
+            })
+    }
+
+    fn headers(&self) -> RequestHeaders {
         RequestHeaders {
             headers: self.headers.iter(),
             req: self,

--- a/tests/test-proxy.rs
+++ b/tests/test-proxy.rs
@@ -81,7 +81,6 @@ fn method_on_http_server() {
 }
 
 #[test]
-#[ignore]
 fn request_body() {
     fn hello_request_body(mut req: Request, mut res: Response) {
         let mut body = String::new();


### PR DESCRIPTION
The request uses a similar approach to consuming the body as the
response does. It is tempting to DRY up that code, but I believe there
are enough subtle differences that keeping it split apart is better for
now.