### PR TITLE
General intermediary request conformance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate futures;
 #[macro_use] extern crate log;
 extern crate env_logger;
-extern crate hyper;
+#[macro_use] extern crate hyper;
 #[macro_use] extern crate rustful;
 extern crate rustc_serialize;
 extern crate tokio_core;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,16 +1,148 @@
 use std::io;
 use std::net::SocketAddr;
 use std::result;
+use std::str;
 use std::thread;
 
 use futures::Future;
-use hyper::{self, Client};
-use hyper::server::{Server, Service, Request, Response, Listening};
+use hyper::{self, Headers, Client, HttpVersion};
 use hyper::client;
+use hyper::header;
+use hyper::server::{self, Server, Service, Listening};
 use tokio_core::reactor::Handle;
 use tokio_service::NewService;
 
 use pool::Pool;
+
+// testing here before sending PR upstream
+// TODO make this typed
+header! { (Via, "Via") => [String] }
+header! { (TE, "TE") => [String] }
+header! { (ProxyAuthorization, "Proxy-Authorization") => [String] }
+header! { (ProxyAuthenticate, "Proxy-Authenticate") => [String] }
+header! { (Trailer, "Trailer") => [String] }
+
+impl Via {
+
+    /// Append a Via header to existing Via header
+    ///
+    /// This is used when the upstream sends a Via header and we need to create a list of Via
+    /// header values.
+    pub fn append(&mut self, other: Via) {
+        let s = format!(", {}", other);
+        self.0.push_str(&s);
+    }
+}
+
+/// Create Via header for proxy to send downstream to origin server
+///
+/// The Via header may already exist, so create a new header based off the upstream value
+pub fn create_via_header(via: Option<& Via>, version: &HttpVersion) -> Via {
+
+    let version = match version {
+        &HttpVersion::Http09 => "0.9",
+        &HttpVersion::Http10 => "1.0",
+        &HttpVersion::Http11 => "1.1",
+        &HttpVersion::H2 => "2",
+        &HttpVersion::H2c => "2",
+        _ => unreachable!(),
+    };
+
+    let value = Via(format!("{} alacrity", version));
+
+    match via {
+        Some(v) => {
+            let mut v = v.clone();
+            v.append(value);
+            v
+        }
+        None => {
+            value
+        }
+    }
+}
+
+/// Remove frontend request headers that should not be sent to backend
+///
+/// This creates a new collection rather than modify the existing one. Hyper can sometimes return
+/// `None` even though a header is removed. Thus, we ignore the result.
+pub fn filter_frontend_request_headers(headers: &Headers) -> Headers {
+
+    let mut h = headers.clone();
+
+    headers.get::<header::Connection>().and_then(|c| {
+        for c_h in &c.0 {
+            match c_h {
+                &header::ConnectionOption::Close => {
+                    let _ = h.remove_raw("Close");
+                }
+
+                &header::ConnectionOption::KeepAlive => {
+                    let _ = h.remove_raw("Keep-Alive");
+                }
+
+                &header::ConnectionOption::ConnectionHeader(ref o) => {
+                    let _ = h.remove_raw(&o);
+                }
+            }
+        }
+
+        Some(())
+    });
+
+    let _ = h.remove::<header::Connection>();
+    let _ = h.remove::<TE>();
+    let _ = h.remove::<header::TransferEncoding>();
+    let _ = h.remove::<ProxyAuthorization>();
+    let _ = h.remove::<Trailer>();
+    let _ = h.remove::<header::Upgrade>();
+
+    h
+}
+
+/// Map a frontend request to a backend request
+///
+/// The primary purpose of this function is to add and remove headers as required by an
+/// intermediary conforming to the HTTP spec.
+fn map_request(req: server::Request, url: &str) -> client::Request {
+    let mut r = client::Request::new(req.method().clone(), url.parse().unwrap());
+
+    let via = create_via_header(
+        req.headers().get::<Via>(),
+        req.version());
+
+    let mut headers = filter_frontend_request_headers(req.headers());
+    headers.set(via);
+    r.headers_mut().extend(headers.iter());
+
+    r.set_body(req.body());
+    r
+}
+
+pub fn filter_backend_response_headers(headers: &Headers) -> Headers {
+    let mut h = headers.clone();
+
+    let _ = h.remove::<header::TransferEncoding>();
+    let _ = h.remove::<ProxyAuthenticate>();
+    let _ = h.remove::<Trailer>();
+    let _ = h.remove::<header::Upgrade>();
+
+    h
+}
+
+/// Map a backend response to a frontend response
+///
+/// The primary purpose of this function is to add and remove headers as required by an
+/// intermediary conforming to the HTTP spec.
+fn map_response(res: client::Response) -> server::Response {
+    let mut r = server::Response::new().with_status(*res.status());
+
+    let headers = filter_backend_response_headers(res.headers());
+    r.headers_mut().extend(headers.iter());
+
+    r.set_body(res.body());
+    r
+}
 
 struct Proxy {
     handle: Handle,
@@ -18,24 +150,17 @@ struct Proxy {
 }
 
 impl Service for Proxy {
-    type Request = Request;
-    type Response = Response;
+    type Request = server::Request;
+    type Response = server::Response;
     type Error = hyper::Error;
-    type Future = Box<Future<Item=Response, Error=Self::Error>>;
+    type Future = Box<Future<Item=server::Response, Error=Self::Error>>;
 
-    fn call(&self, req: Request) -> Self::Future {
+    fn call(&self, req: server::Request) -> Self::Future {
         let addr = self.pool.get().expect("Failed to get address from pool");
         let url = format!("http://{}{}", addr, req.path().unwrap());
         debug!("Preparing backend request to {:?}", url);
 
-        let mut client_req = client::Request::new(req.method().clone(), url.parse().unwrap());
-
-        // TOOD put this in a separate function. it should filter out headers we should not pass
-        // we should also add headers like via
-        {
-            let mut client_headers = client_req.headers_mut();
-            client_headers.extend(req.headers().iter());
-        }
+        let client_req = map_request(req, &url);
 
         // TODO store client in Proxy object
         let client = Client::new(&self.handle.clone());
@@ -43,15 +168,7 @@ impl Service for Proxy {
             debug!("Response: {}", res.status());
             debug!("Headers: \n{}", res.headers());
 
-            // transform client::Response into server::Response
-            let mut server_response = Response::new().with_status(*res.status());
-
-            {
-                let mut server_headers = server_response.headers_mut();
-                server_headers.extend(res.headers().iter());
-            }
-
-            server_response.set_body(res.body());
+            let server_response = map_response(res);
 
             ::futures::finished(server_response)
         }).map_err(|e| {
@@ -69,8 +186,8 @@ struct NewProxyService {
 }
 
 impl NewService for NewProxyService {
-    type Request = Request;
-    type Response = Response;
+    type Request = server::Request;
+    type Response = server::Response;
     type Error = hyper::Error;
     type Instance = Proxy;
 
@@ -103,4 +220,112 @@ pub fn listen(addr: SocketAddr, pool: Pool) -> result::Result<(thread::JoinHandl
     });
 
     Ok((handle, rx.recv().unwrap()))
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper::{HttpVersion, Headers};
+    use hyper::header;
+
+    use super::*;
+
+    #[test]
+    #[ignore]
+    /// Send HTTP 1.0 request and ensure proxy sends HTTP 1.1
+    ///
+    /// Per RFC 7230 Section 2.6 - MUST send own HTTP version
+    fn test_must_send_own_http_version() {
+        // logic is in, waiting for mocked request support to test
+    }
+
+    #[test]
+    #[ignore]
+    /// Send HTTP request and ensure proxy sets proper Via header
+    ///
+    /// Per RFC 7230 Section 5.7.1
+    fn test_proxy_sets_via_header() {
+        // logic is in, waiting for mocked request support to test
+    }
+
+    #[test]
+    fn test_create_via_header() {
+        let via = Via("1.0 proxy".to_owned());
+        let version = HttpVersion::Http11;
+
+        let given = create_via_header(None, &version);
+
+        assert_eq!(Via("1.1 alacrity".to_owned()), given);
+
+        let given = create_via_header(Some(&via), &version);
+
+        assert_eq!(Via("1.0 proxy, 1.1 alacrity".to_owned()), given);
+    }
+
+    #[test]
+    /// Per RFC 2616 Section 13.5.1 - MUST remove hop-by-hop headers
+    /// Per RFC 7230 Section 6.1 - MUST remove Connection and Connection option headers
+    fn test_filter_frontend_request_headers() {
+
+        let bad = vec![
+            ("TE", "gzip"),
+            ("Transfer-Encoding", "chunked"),
+            ("Host", "example.net"),
+            ("Connection", "Keep-Alive, Foo, Bar"),
+            ("Foo", "abc"),
+            ("Foo", "def"),
+            ("Keep-Alive", "timeout=30"),
+            ("Proxy-Authorization", "randombase64value"),
+            ("Trailer", "X-Random-Header"),
+            ("Upgrade", "HTTP/2.0, SHTTP/1.3, IRC/6.9, RTA/x11"),
+        ];
+
+        let mut headers = Headers::new();
+
+        for (name, value) in bad {
+            headers.set_raw(name, value);
+        }
+
+        let given = filter_frontend_request_headers(&headers);
+
+        // defining these here only to let me assert
+        header! { (Foo, "Foo") => [String] }
+        header! { (KeepAlive, "Keep-Alive") => [String] }
+
+        assert_eq!(false, given.has::<TE>());
+        assert_eq!(false, given.has::<header::TransferEncoding>());
+        assert_eq!(true, given.has::<header::Host>());
+        assert_eq!(false, given.has::<header::Connection>());
+        assert_eq!(false, given.has::<Foo>());
+        assert_eq!(false, given.has::<KeepAlive>());
+        assert_eq!(false, given.has::<ProxyAuthorization>());
+        assert_eq!(false, given.has::<Trailer>());
+        assert_eq!(false, given.has::<header::Upgrade>());
+    }
+
+    #[test]
+    /// Per RFC 2616 Section 13.5.1 - MUST remove hop-by-hop headers
+    fn test_filter_backend_response_headers() {
+
+        let bad = vec![
+            ("Transfer-Encoding", "chunked"),
+            ("Host", "example.net"),
+            ("Proxy-Authenticate", "randombase64value"),
+            ("Trailer", "X-Random-Header"),
+            ("Upgrade", "HTTP/2.0"),
+        ];
+
+        let mut headers = Headers::new();
+
+        for (name, value) in bad {
+            headers.set_raw(name, value);
+        }
+
+        let given = filter_backend_response_headers(&headers);
+
+        assert_eq!(false, given.has::<header::TransferEncoding>());
+        assert_eq!(true, given.has::<header::Host>());
+        assert_eq!(false, given.has::<ProxyAuthenticate>());
+        assert_eq!(false, given.has::<Trailer>());
+        assert_eq!(false, given.has::<header::Upgrade>());
+    }
 }


### PR DESCRIPTION
First pass at trying to make alacrity conform to the RFC 2616 and 7230
regarding behavior of gateways.