### PR TITLE
Implement naive health checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "rustful 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (git+https://github.com/tokio-rs/tokio-service)",
+ "tokio-timer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -670,6 +671,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-timer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "toml"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +840,7 @@ dependencies = [
 "checksum tokio-proto 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c0d6031f94d78d7b4d509d4a7c5e1cdf524a17e7b08d1c188a83cf720e69808"
 "checksum tokio-service 0.1.0 (git+https://github.com/tokio-rs/tokio-service)" = "<none>"
 "checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
+"checksum tokio-timer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "36016cdc103d9b52df30b25002b8e8aae16c742dd72d6ba339ce02e674272d89"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "07eaeb7689bb7fca7ce15628319635758eda769fed481ecfe6686ddef2600616"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ futures = "0.1.1"
 hyper = { git = "https://github.com/hyperium/hyper" }
 tokio-core = "0.1"
 tokio-service = { git = "https://github.com/tokio-rs/tokio-service" }
+tokio-timer = "0.1.0"
 
 rustc-serialize = "0.3.19"
 

--- a/README.md
+++ b/README.md
@@ -41,21 +41,24 @@ POST /servers
 {
    "ip": "120.0.0.1",
    "port": "8080",
-   "check": {
-      "type": "tcp"
-   }
 }
 ```
+
+Example: `curl -vvv localhost:8687/servers -d '{"ip":"127.0.0.1", "port":"12345"}'`
 
 ### Removing A Server
 
 Note: It is more common for a server to fall out of the pool after `n` health checks fail.
 
 ```
-DELETE /servers/:id
+DELETE /servers/:ip/:port
 ```
 
+Example: `curl -vvv -X DELETE localhost:8687/servers/127.0.0.1/12345`
+
 ### Stats
+
+_Work in progress._
 
 ```
 GET /stats
@@ -75,6 +78,8 @@ GET /stats
 ```
 
 #### Detailed Stats
+
+_Work in progress._
 
 ```
 GET /stats/detail

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,0 +1,69 @@
+use std::time::Duration;
+
+use futures::*;
+use tokio_timer::*;
+use tokio_core::reactor::Core;
+use hyper::{Client, Url};
+
+use pool::Pool;
+
+pub struct HealthCheck {
+    interval: Duration,
+    pool: Pool,
+    uri_path: String,
+}
+
+impl HealthCheck {
+    pub fn new(interval: Duration, pool: Pool, uri_path: String) -> HealthCheck {
+
+        HealthCheck {
+            interval: interval,
+            pool: pool,
+            uri_path: uri_path,
+        }
+    }
+
+    pub fn run(&self) {
+        let mut core = Core::new().unwrap();
+        let timer = Timer::default();
+
+        let handle = core.handle();
+        let client = Client::new(&handle);
+
+        let pool = self.pool.clone();
+        let work = timer.interval(self.interval).for_each(move |()| {
+            let servers = pool.all();
+            for server in servers {
+                let url = format!("http://{}{}", server.addr(), self.uri_path);
+                let url = Url::parse(&url).unwrap();
+                debug!("Health check {:?}", url);
+
+                let pool1 = pool.clone();
+                let pool2 = pool.clone();
+                let server1 = server.clone();
+                let server2 = server.clone();
+                let req = client.get(url).and_then(move |res| {
+                    debug!("Response: {}", res.status());
+                    debug!("Headers: \n{}", res.headers());
+
+                    if ! res.status().is_success() {
+                        info!("Removing {:?} from pool", server1);
+                        pool1.remove(&server1);
+                    }
+
+                    ::futures::finished(())
+                }).map_err(move |e| {
+                    error!("Error connecting to backend: {:?}", e);
+                    info!("Removing {:?} from pool", server2);
+                    pool2.remove(&server2);
+                });
+
+                handle.spawn(req);
+            }
+
+            Ok(())
+        }).map_err(|_| {});
+
+        core.run(work).unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,9 @@ extern crate env_logger;
 extern crate rustc_serialize;
 extern crate tokio_core;
 extern crate tokio_service;
+extern crate tokio_timer;
 
-// pub mod for now until the entire API is used internally
 pub mod pool;
 pub mod proxy;
-//pub mod backend;
-//pub mod frontend;
 pub mod mgmt;
+pub mod health;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -157,8 +157,8 @@ impl Service for Proxy {
     type Future = Box<Future<Item=server::Response, Error=Self::Error>>;
 
     fn call(&self, req: server::Request) -> Self::Future {
-        let addr = self.pool.get().expect("Failed to get address from pool");
-        let url = format!("http://{}{}", addr, req.path());
+        let server = self.pool.get().expect("Failed to get server from pool");
+        let url = format!("http://{}{}", server.addr(), req.path());
         debug!("Preparing backend request to {:?}", url);
 
         let client_req = map_request(req, &url);


### PR DESCRIPTION
This my first pass at a health check. I thought about re-using an existing tokio Core, but if we use tokio-pool (or something like it) then we have a Core per thread. I don't see how we can get away with not having a dedicated thread to do health checks.

We may need to introduce some basic configuration at this point so the uri path for the health check is not hard-coded. I have to think about that a bit too.